### PR TITLE
docs: change GitHub Actions README badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # shelljs-plugin-tr
 
-[![Build Status](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Factions-badge.atrox.dev%2Fnfischer%2Fshelljs-plugin-tr%2Fbadge%3Fref%3Dmain&style=flat-square)](https://actions-badge.atrox.dev/nfischer/shelljs-plugin-tr/goto?ref=main)
+[![GitHub Actions](https://img.shields.io/github/actions/workflow/status/nfischer/shelljs-plugin-tr/main.yml?style=flat-square&logo=github)](https://github.com/nfischer/shelljs-plugin-tr/actions/workflows/main.yml)
 [![npm](https://img.shields.io/npm/v/shelljs-plugin-tr.svg?style=flat-square)](https://www.npmjs.com/package/shelljs-plugin-tr)
 [![shelljs-plugin](https://img.shields.io/badge/shelljs-plugin-brightgreen.svg?style=flat-square)](https://github.com/shelljs/shelljs/wiki/Using-ShellJS-Plugins)
 


### PR DESCRIPTION
This changes the README to use a standard shields.io badge for GitHub Actions. The custom badge
(https://github.com/Atrox/github-actions-badge) was cool, but the atrox.dev link doesn't work reliably. I noticed that shields has support for this now, so there's no reason to use a custom badge.

One notably difference is that this badge says the build is passing even if there's a job still in progress.