### PR TITLE
chore: update shelljs and drop old node support

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,14 +10,9 @@ jobs:
       fail-fast: false
       matrix:
         node-version:
-          - 4
-          - 6
-          - 8
-          - 10
-          - 12
-          - 14
-          - 16
           - 18
+          - 20
+          - 22
         os:
           - ubuntu-latest
           - macos-latest
@@ -28,7 +23,4 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
       - run: npm install
-      - run: npm run test-without-lint
-      - name: run lint (node >= 6)
-        run: npm run lint
-        if: matrix.node-version >= 6
+      - run: npm test

--- a/package.json
+++ b/package.json
@@ -6,7 +6,6 @@
   "scripts": {
     "posttest": "npm run lint --silent",
     "test": "mocha",
-    "test-without-lint": "mocha",
     "lint": "eslint .",
     "changelog": "shelljs-changelog",
     "release:major": "shelljs-release major",
@@ -29,15 +28,15 @@
     "eslint-config-airbnb-base": "^13.1.0",
     "eslint-plugin-import": "^2.17.3",
     "mocha": "^5.2.0",
-    "shelljs": "^0.8.5",
+    "shelljs": "^0.9.1",
     "shelljs-changelog": "^0.2.6",
     "shelljs-release": "^0.5.2",
     "should": "^13.2.3"
   },
   "peerDependencies": {
-    "shelljs": "^0.8.5"
+    "shelljs": "^0.9.1"
   },
   "engines": {
-    "node": ">=4"
+    "node": ">=18"
   }
 }


### PR DESCRIPTION
No change to logic. This updates the ShellJS peer dependency to the latest release. This also drops support for all node versions prior to v18 to match ShellJS's version range, and adds in node v20 and v22.

Test: npm test