### PR TITLE
chore: update GitHub Actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,13 +13,15 @@ jobs:
           - 18
           - 20
           - 22
+          - 24
+          - 26
         os:
           - ubuntu-latest
           - macos-latest
           - windows-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
           node-version: ${{ matrix.node-version }}
       - run: npm install


### PR DESCRIPTION
No change to logic. This updates GitHub Actions to their latest
versions. This also ensures we are testing up through Node v26.